### PR TITLE
Added test for getImage

### DIFF
--- a/lib/api/pictogram_api.dart
+++ b/lib/api/pictogram_api.dart
@@ -96,9 +96,9 @@ class PictogramApi {
   /// the department
   ///
   /// [id] ID of the pictogram for which the image should be fetched
-  Observable<MemoryImage> getImage(int id) {
+  Observable<Image> getImage(int id) {
     return _http.get('/$id/image/raw').map((Response res) {
-      return MemoryImage(res.response.bodyBytes);
+      return Image.memory(res.response.bodyBytes);
     });
   }
 }

--- a/lib/api/pictogram_api.dart
+++ b/lib/api/pictogram_api.dart
@@ -96,10 +96,9 @@ class PictogramApi {
   /// the department
   ///
   /// [id] ID of the pictogram for which the image should be fetched
-  Observable<Image> getImage(int id) {
-    // TODO(boginw): test this method
+  Observable<MemoryImage> getImage(int id) {
     return _http.get('/$id/image/raw').map((Response res) {
-      return Image.memory(res.response.bodyBytes);
+      return MemoryImage(res.response.bodyBytes);
     });
   }
 }

--- a/lib/http/http_mock.dart
+++ b/lib/http/http_mock.dart
@@ -1,6 +1,7 @@
 import 'package:api_client/http/http.dart';
 import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
+import 'package:http/http.dart' as http;
 
 /// HTTP Method
 // ignore: public_member_api_docs
@@ -124,8 +125,17 @@ class HttpMock implements Http {
       if (response is Exception) {
         throw response;
       }
+      http.Response httpResponse;
+      Map<String, dynamic> json;
 
-      return Response(null, response);
+      if(response is Map<String, dynamic>) {
+        // The response is parsed json
+        json = response;
+      } else if (response is List<int>) {
+        // The response is a binary stream
+        httpResponse = http.Response.bytes(response, 200);
+      }
+      return Response(httpResponse, json);
     });
   }
 }

--- a/test/api/pictogram_api_test.dart
+++ b/test/api/pictogram_api_test.dart
@@ -138,9 +138,9 @@ void main() {
       3,
       4,
     ]);
-    pictogramApi.getImage(grams[0].id).listen(expectAsync1((Image image) {
-      if(image.image is MemoryImage) {
-        final MemoryImage currentImage = image.image as MemoryImage;
+    pictogramApi.getImage(grams[0].id).listen(expectAsync1((Image imageWidget) {
+      if(imageWidget.image is MemoryImage) {
+        final MemoryImage currentImage = imageWidget.image as MemoryImage;
         expect(currentImage.bytes, imagebytes);
       } else {
         fail('Image is not a MemoryImage');

--- a/test/api/pictogram_api_test.dart
+++ b/test/api/pictogram_api_test.dart
@@ -5,6 +5,7 @@ import 'package:api_client/models/pictogram_model.dart';
 import 'package:api_client/api/pictogram_api.dart';
 import 'package:api_client/http/http_mock.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
 
 void main() {
   PictogramApi pictogramApi;
@@ -128,6 +129,22 @@ void main() {
       'errorProperties': <dynamic>[],
       'errorKey': 'NoError',
     });
+  });
+
+  test('Get raw image', () {
+    final List<int> imagebytes = Uint8List.fromList(<int>[
+      1,
+      2,
+      3,
+      4,
+    ]);
+    pictogramApi.getImage(grams[0].id).listen(expectAsync1((MemoryImage image) {
+      expect(image.bytes, imagebytes);
+    }));
+
+    httpMock
+        .expectOne(url: '/${grams[0].id}/image/raw', method: Method.get)
+        .flush(imagebytes);
   });
 
   tearDown(() {

--- a/test/api/pictogram_api_test.dart
+++ b/test/api/pictogram_api_test.dart
@@ -138,8 +138,13 @@ void main() {
       3,
       4,
     ]);
-    pictogramApi.getImage(grams[0].id).listen(expectAsync1((MemoryImage image) {
-      expect(image.bytes, imagebytes);
+    pictogramApi.getImage(grams[0].id).listen(expectAsync1((Image image) {
+      if(image.image is MemoryImage) {
+        final MemoryImage currentImage = image.image as MemoryImage;
+        expect(currentImage.bytes, imagebytes);
+      } else {
+        fail('Image is not a MemoryImage');
+      }
     }));
 
     httpMock


### PR DESCRIPTION
This PR adds a test for `getImage`.

The return type of the function has been changed to a [MemoryImage](https://api.flutter.dev/flutter/painting/MemoryImage-class.html) instead of an [Image-widget](https://api.flutter.dev/flutter/widgets/Image-class.html) to be able to test the bytes returned.
This then requires all the functions using this function to handle this change and should not be merged into master before this has been done.

Furthermore, the `HttpMock` now supports passing the response to a byte array.

Fixes: #2 
