### PR TITLE
Fixes #28

### DIFF
--- a/lib/api/account_api.dart
+++ b/lib/api/account_api.dart
@@ -39,7 +39,7 @@ class AccountApi {
       'username': username,
       'password': password,
       'departmentId': departmentId,
-      'role': role.toString(),
+      'role': role.toString().split('.').last,
     };
 
     if (displayName != null) {


### PR DESCRIPTION
Closes #28
Example;
Before Citizen role would create the string "Role.Citizen".
After Citizen role will create the string "Citizen"