### PR TITLE
set codecov to informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,6 +9,9 @@ coverage:
     project:
       default:
         informational: true
+    patch:
+      default:
+        informational: true
         
 comment:
   layout: "diff,flags,files"

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,11 @@ coverage:
   precision: 1
   round: down
   range: "70...100"
-
+  status:
+    project:
+      default:
+        informational: true
+        
 comment:
   layout: "diff,flags,files"
   behavior: default


### PR DESCRIPTION
Set codecov to informational. 
This makes it so that codecov won't block merges, but just inform about the change code coverage.