### PR TITLE
Feature web api/227: Not able to get the role of a user

### DIFF
--- a/lib/api/account_api.dart
+++ b/lib/api/account_api.dart
@@ -28,12 +28,6 @@ class AccountApi {
         Stream<bool>.fromFuture(_persist.set('token', res.json['data'])));
   }
 
-  ///Get the role of the user with the username inputted
-  Stream<String> role(String username) {
-
-    return _http.get('/$username/role')
-        .map((Response res) => res.json['data']);
-  }
   /// Register a new user
   ///
   /// [username] The users username

--- a/lib/api/user_api.dart
+++ b/lib/api/user_api.dart
@@ -29,7 +29,7 @@ class UserApi {
   }
 
   ///Get the role of the user with the username inputted
-  Stream<String> role(String username) {
+  Stream<Int> role(String username) {
     return _http
         .get('/$username/role')
         .map((Response res) => res.json['data']);

--- a/lib/api/user_api.dart
+++ b/lib/api/user_api.dart
@@ -29,7 +29,7 @@ class UserApi {
   }
 
   ///Get the role of the user with the username inputted
-  Stream<Int> role(String username) {
+  Stream<int> role(String username) {
     return _http
         .get('/$username/role')
         .map((Response res) => res.json['data']);

--- a/lib/api/user_api.dart
+++ b/lib/api/user_api.dart
@@ -28,6 +28,13 @@ class UserApi {
         .map((Response res) => GirafUserModel.fromJson(res.json['data']));
   }
 
+  ///Get the role of the user with the username inputted
+  Stream<String> role(String username) {
+    return _http
+        .get('/$username/role')
+        .map((Response res) => res.json['data']);
+  }
+
   /// Updates the user with the information in GirafUserModel
   ///
   /// [user] The updated user

--- a/lib/api/user_api.dart
+++ b/lib/api/user_api.dart
@@ -29,6 +29,8 @@ class UserApi {
   }
 
   ///Get the role of the user with the username inputted
+  ///
+  /// [username] Username of the user
   Stream<int> role(String username) {
     return _http
         .get('/$username/role')

--- a/lib/models/enums/role_enum.dart
+++ b/lib/models/enums/role_enum.dart
@@ -1,2 +1,2 @@
 // ignore_for_file: public_member_api_docs
-enum Role { Citizen, Department, Guardian, SuperUser }
+enum Role { Citizen, Department, Trustee, Guardian, SuperUser }

--- a/lib/models/enums/role_enum.dart
+++ b/lib/models/enums/role_enum.dart
@@ -1,2 +1,2 @@
 // ignore_for_file: public_member_api_docs
-enum Role { Citizen, Department, Trustee, Guardian, SuperUser }
+enum Role { Citizen, Department, Guardian, SuperUser, Trustee }

--- a/test/api/user_api_test.dart
+++ b/test/api/user_api_test.dart
@@ -79,6 +79,20 @@ Future<void> main() async {
     });
   });
 
+  test('Should get the role endpoint', () {
+    userApi.role(user.username).listen(expectAsync1((int roleIndex) {
+      expect(roleIndex, user.role.index);
+    }));
+
+    httpMock
+        .expectOne(url: '/${user.username}/role', method: Method.get)
+        .flush(<String, dynamic>{
+      'data': user.role.index,
+      'message': '',
+      'errorKey': 'NoError'
+    });
+  });
+
   test('Should update user with ID', () {
     userApi.update(user).listen(expectAsync1((GirafUserModel specUser) {
       expect(specUser.toJson(), user.toJson());

--- a/test/models/role_enum_test.dart
+++ b/test/models/role_enum_test.dart
@@ -7,5 +7,6 @@ void main() {
     expect(Role.Department.index, 1);
     expect(Role.Guardian.index, 2);
     expect(Role.SuperUser.index, 3);
+    expect(Role.Trustee.index, 4);
   });
 }


### PR DESCRIPTION
# Description
Prerequisite to pull request: aau-giraf/weekplanner#801

The method for getting the role from the server, has been moved to the correct api (user api, instead of account api), as the getRole method is a part of the UserController and not the AccountController on the web-api.

Related to issue aau-giraf/web-api#227

## Type of change

*Please delete options that are not relevant.*

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration*
It has been run locally to verify that it works, and a test has been written for the endpoint

**Development Configuration**
* Toolchain: Android Studio

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules