### PR TITLE
Add element to enum ActivityState

### DIFF
--- a/lib/models/enums/activity_state_enum.dart
+++ b/lib/models/enums/activity_state_enum.dart
@@ -1,2 +1,2 @@
 // ignore_for_file: public_member_api_docs
-enum ActivityState { Normal, Active, Canceled, Completed }
+enum ActivityState { Normal, Active, Canceled, Completed, Removed }


### PR DESCRIPTION
# Description

Our group (FRONT 2):
1.  Fatma Mondher Al-Beidhnay - falbei22@student.aau.dk
2. Claus D. Hansen - cdha20@student.aau.dk
3. Thuy Hai Le - thle21@student.aau.dk
4. Frederik Bendix Sørensen - fsare17@student.aau.dk

We are developing 'Drag and drop' functionality for activities (Issue#945). We have completed this issue and successfully tested it on our computer by adding 'Removed' to the enum ActivityState { Normal, Active, Canceled, Completed, Removed }.
Now, we would like to add 'Removed' to the enum in the API client on Github to be able to merge the code.